### PR TITLE
feat($point): New `point` parameter for `LineChart`

### DIFF
--- a/packages/lib/src/js/charts/abstractChart.js
+++ b/packages/lib/src/js/charts/abstractChart.js
@@ -57,6 +57,9 @@ export default class AbstractChart {
   isNestedArrayOfArrays = false
   isNestedArrayOfObjects = false
 
+  // Point
+  point = { color: null, radius: 3, fillOpacity: 1, strokeWidth: 0, strokeColor: null }
+
   /**
    * Instantiate a new abstract chart.
    * This isn't meant to be called directly, it is called by the chart implementations.
@@ -80,6 +83,7 @@ export default class AbstractChart {
    * @param {Function} [tooltipFunction] function that receives a data object and returns the string displayed as tooltip.
    * @param {Array} [legend] names of the sub-arrays of data, used as legend labels.
    * @param {String | Object} [legendTarget] DOM node to which the legend should be mounted.
+   * @param {Object} [point={ color: null, radius: 3, fillOpacity: 1, strokeWidth: 0, strokeColor: null }] point object specifying color, radius, fillOpacity, strokeWidth and strokeColor.
    */
   constructor ({
     data,
@@ -101,6 +105,7 @@ export default class AbstractChart {
     tooltipFunction,
     legend,
     legendTarget,
+    point,
     ...custom
   }) {
     // check that at least some data was specified
@@ -115,6 +120,7 @@ export default class AbstractChart {
     this.markers = markers ?? this.markers
     this.legend = legend ?? this.legend
     this.legendTarget = legendTarget ?? this.legendTarget
+    this.point = point ?? this.point
 
     // convert string accessors to functions if necessary
     this.xAccessor = typeof xAccessor === 'string'

--- a/packages/lib/src/js/charts/line.js
+++ b/packages/lib/src/js/charts/line.js
@@ -37,7 +37,11 @@ export default class LineChart extends AbstractChart {
         yAccessor: this.yAccessor,
         xScale: this.xScale,
         yScale: this.yScale,
-        radius: 3
+        radius: this.point.radius || 3,
+        color: this.point.color || this.colors[index],
+        fillOpacity: this.point.fillOpacity,
+        strokeWidth: this.point.strokeWidth,
+        strokeColor: this.point.strokeColor
       })
       line.mountTo(this.container)
     })
@@ -115,10 +119,13 @@ export default class LineChart extends AbstractChart {
 
         points.forEach(point => {
           const index = point.arrayIndex || 0
-          const color = this.colors[index]
+          const color = this.point.color || this.colors[index]
+          const fillOpacity = this.point.fillOpacity
+          const strokeWidth = this.point.strokeWidth
+          const strokeColor = this.point.strokeColor
 
           // set hover point
-          this.delaunayPoints[index].update({ data: point, color })
+          this.delaunayPoints[index].update({ data: point, color, fillOpacity, strokeWidth, strokeColor })
           if (!this.delaunayPoints[index].shapeObject) {
             this.delaunayPoints[index].mountTo(this.container)
           }

--- a/packages/lib/src/js/components/abstractShape.js
+++ b/packages/lib/src/js/components/abstractShape.js
@@ -6,6 +6,7 @@ export default class AbstractShape {
   color = null
   fillOpacity = 1
   strokeWidth = 0
+  strokeColor = null
 
   /**
    * Create a new abstract shape.
@@ -18,13 +19,14 @@ export default class AbstractShape {
    * @param {Number} [fillOpacity=1] opacity of the shape fill.
    * @param {Number} [strokeWidth=0] width of the stroke around the shape.
    */
-  constructor ({ data, xScale, yScale, color, fillOpacity, strokeWidth }) {
+  constructor ({ data, xScale, yScale, color, fillOpacity, strokeWidth, strokeColor }) {
     this.data = data
     this.xScale = xScale
     this.yScale = yScale
     this.color = color
     this.fillOpacity = fillOpacity
     this.strokeWidth = strokeWidth
+    this.strokeColor = strokeColor
   }
 
   /**
@@ -60,9 +62,10 @@ export default class AbstractShape {
    * @param {String} color new color of the shape.
    * @param {Number} fillOpacity new fill opacity of the shape.
    * @param {Number} strokeWidth new stroke width of the shape.
+   * @param {String} strokeColor new stroke color of the shape.
    * @returns {void}
    */
-  updateGeneric ({ color, fillOpacity, strokeWidth }) {
+  updateGeneric ({ color, fillOpacity, strokeWidth, strokeColor }) {
     if (color) {
       this.color = color
       if (this.shapeObject) this.shapeObject.attr('fill', this.color)
@@ -74,6 +77,10 @@ export default class AbstractShape {
     if (strokeWidth) {
       this.strokeWidth = strokeWidth
       if (this.shapeObject) this.shapeObject.attr('stroke-width', this.strokeWidth)
+    }
+    if (strokeColor) {
+      this.strokeColor = strokeColor
+      if (this.shapeObject) this.shapeObject.attr('stroke', this.strokeColor)
     }
   }
 


### PR DESCRIPTION
This adds a `point` parameter for modifying color, opacity radius and stroke props on rendered SVG rather than using CSS-based modifiers. 

```
LineChart({
    ...
    point: {
        radius: 8,
        fillOpacity: 0.7,
        color: '#ffffff',
        strokeWidth: 3,
        strokeColor: '#3388ff'
    }
    ...
})
```

![Screenshot](https://user-images.githubusercontent.com/29415656/79930272-f2febf00-83fc-11ea-81c8-df9979926013.png)
